### PR TITLE
Preserve entropy of x

### DIFF
--- a/js/coin.js
+++ b/js/coin.js
@@ -56,8 +56,8 @@
 		x += coinjs.random(64);
 		x += x+''+x;
 		var r = x;
-		for(i=0;i<(x).length;i++){
-			r = Crypto.SHA256(r);
+		for(i=0;i<(x).length/16;i++){
+			r = Crypto.SHA256(r.concat(x));
 		}
 		return r;
 	}


### PR DESCRIPTION
Iterative hashing without attempting to preserve entropy is not best practice.

It would be best to use PBKDF2... but this is better than currently.

I lowered iteration count to keep the same amount of time for the function. with (x).length iterations (about 1550 - 1600 for me each time), it was almost 16 times slower, and if divided by 16 the whole process took the same amount of time. (around 31 milliseconds)

Considering the length is usually around 1600 for me, that means somewhere around 100 iterations including the entirety of x in each hash concatenated with the current iteration of r.
