### PR TITLE
Add ability to send to stealth address

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Coinb.in supports a number of key features such as:
 - Broadcast transactions.
 - nLockTime support.
 - Add custom data to transactions with the use of OP_RETURN.
+- Support current Dark Wallet Stealth Address structure (as of version Alpha 7) for outputs.
 - Brain wallet support.
 - Compatible with bitcoin-qt
 - An offical .onion address for tor users.

--- a/js/coinbin.js
+++ b/js/coinbin.js
@@ -364,9 +364,17 @@ $(document).ready(function() {
 		$("#recipients .row").removeClass('has-error');
 
 		$.each($("#recipients .row"), function(i,o){
-			var a = ($(".address",o).val()).substr(0,80);
-			if(((a!="") && coinjs.addressDecode(a)) && $(".amount",o).val()!=""){ // address
+			var a = ($(".address",o).val());
+			var ad = coinjs.addressDecode(a)
+			if(((a!="") && (ad.version === 0 || ad.version === 5)) && $(".amount",o).val()!=""){ // address
 				tx.addoutput(a, $(".amount",o).val());
+			} else if (((a!="") && ad.version === 42) && $(".amount",o).val()!=""){ // stealth address
+				var stealth = coinjs.stealthDecode(a);
+				if (stealth == false) {
+					$(o).addClass('has-error');
+					return;
+				}
+				tx.addstealth(stealth, $(".amount",o).val());
 			} else if (((($("#opReturn").is(":checked")) && a.match(/^[a-f0-9]+$/ig)) && a.length<80) && (a.length%2)==0) { // data
 				tx.adddata(a);
 			} else { // neither address nor data


### PR DESCRIPTION
Currently works with sending to Dark Wallet Mainnet stealth addresses.

To test, please use Dark Wallet, create Main net wallet, and copy over a stealth address from one of the pockets.

Note: Dark Wallet stealth sends are only synced to dark wallet after 1 confirmation. (it only scans blocks for stealth, not unconfirmed txes)

Stealth is happening.
1AuVv658Zdn5LfuLJK1Jpv4BNh8Z5ZbjnZ
bip32jp.github.io
