### PR TITLE
Add QR code buttons for transaction data textareas

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,7 +538,12 @@
 							<label>Transaction</label>
 							<p>The transaction below has been generated and encoded. It can be broadcasted once it has been signed.</p>
 							<br>
-							<textarea class="form-control" style="height:150px" readonly></textarea>
+                            <div class="input-group">
+                                <textarea class="form-control" style="height:150px" readonly></textarea>
+                                <span class="input-group-btn">
+                                    <button class="qrcodeBtn btn btn-default" type="button" data-toggle="modal" data-target="#modalQrcode"><span class="glyphicon glyphicon-qrcode"></span></button>
+                                </span>
+                            </div>
 							<p class="text-muted">Size: <span class="txSize">0</span> <i>bytes</i></p>
 						</div>
 
@@ -740,8 +745,13 @@
 						</div>
 						<div class="row">
 							<div class="col-md-12">
-								<label for="signTransaction">Transaction</label>
-								<textarea type="text" id="signTransaction" class="form-control" style="height:125px"></textarea>
+                                <label for="signTransaction">Transaction</label>
+                                <div class="input-group">
+                                    <textarea type="text" id="signTransaction" class="form-control" style="height:125px"></textarea>
+                                    <span class="input-group-btn">
+                                        <button class="qrcodeBtn btn btn-default" type="button" data-toggle="modal" data-target="#modalQrcode"><span class="glyphicon glyphicon-qrcode"></span></button>
+                                    </span>
+                                </div>
 							</div>
 						</div>
 						<br>
@@ -753,7 +763,12 @@
 						<div class="alert alert-success hidden" id="signedData">
 							<label>Signed transaction</label>
 							<p>The above transaction has been signed:</p>
-							<textarea class="form-control script" style="height:160px" readonly></textarea>
+                            <div class="input-group">
+                                <textarea class="form-control script" style="height:160px" readonly></textarea>
+                                <span class="input-group-btn">
+                                    <button class="qrcodeBtn btn btn-default" type="button" data-toggle="modal" data-target="#modalQrcode"><span class="glyphicon glyphicon-qrcode"></span></button>
+                                </span>
+                            </div>
 							<p class="text-muted">Size: <span class="txSize">0</span> <i>bytes</i></p>
 						</div>
 

--- a/js/coinbin.js
+++ b/js/coinbin.js
@@ -929,8 +929,18 @@ $(document).ready(function() {
 	$(".qrcodeBtn").click(function(){
 		$("#qrcode").html("");
 		var thisbtn = $(this).parent().parent();
-		var qrcode = new QRCode("qrcode");
-		qrcode.makeCode("bitcoin:"+$('.address',thisbtn).val());
+		
+		if($('textarea',$(this).closest('.input-group')).length){
+			var qrcode = new QRCode("qrcode",{width:512,height:512});
+			var qrstr = $('textarea',$(this).closest('.input-group')).val();
+			if(qrstr.length > 2000){
+				$("#qrcode").html("<p>Sorry the data is too long for the QR generator.</p>");
+			}
+		}else{
+			var qrcode = new QRCode("qrcode");
+			var qrstr = "bitcoin:"+$('.address',thisbtn).val();
+		}
+		qrcode.makeCode(qrstr);
 	});
 
 	$('input[title!=""], abbr[title!=""]').tooltip({'placement':'bottom'});

--- a/js/coinbin.js
+++ b/js/coinbin.js
@@ -935,6 +935,7 @@ $(document).ready(function() {
 			var qrstr = $('textarea',$(this).closest('.input-group')).val();
 			if(qrstr.length > 2000){
 				$("#qrcode").html("<p>Sorry the data is too long for the QR generator.</p>");
+				return;
 			}
 		}else{
 			var qrcode = new QRCode("qrcode");


### PR DESCRIPTION
This is useful for transferring transaction data to offline computers.

Uses can click on the QR code button next to the transaction data textarea.