### PR TITLE
fixed issue with copying the script URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,7 +370,7 @@
 							<p>This script should be <i>saved and should be shared with all the participants before a payment is made</i>, so they may validate the authenticity of the address, it will also be used later to release the bitcoins.</p>
 							<textarea class="form-control script" style="height:160px" readonly></textarea>
 							<label>Shareable URL</label>
-							<input type="text" class="scriptUrl form-control" disabled>
+							<input type="text" class="scriptUrl form-control" readonly>
 						</div>
 
 						<input type="button" class="btn btn-primary" value="Submit" id="newMultiSigAddress">


### PR DESCRIPTION
I noticed, at least on Firefox, that it is impossible to highlight and copy the script URL. I fixed this by changing the "disabled" attribute to "readonly."