### PR TITLE
Adding dogecoin support to coinb.in

### DIFF
--- a/index.html
+++ b/index.html
@@ -970,6 +970,7 @@
 								<select class="form-control" id="coinjs_coin">
 									<option value="bitcoin_mainnet" rel="0x00;0x80;0x05;0x488b21e;0x488ade4;coinb.in;coinb.in">Bitcoin (mainnet)</option>
 									<option value="litecoin_mainnet" rel="0x30;0xb0;0x05;0x019da462;0x019d9cfe;blockr.io_litecoin;chain.so_litecoin">Litecoin (mainnet)</option>
+									<option value="dogecoin_mainnet" rel="0x1e;0x9e;0x16;0x0827421e;0x089944e4;chain.so_dogecoin;chain.so_dogecoin">Dogecoin (mainnet)</option>
 									<option value="shadowcash_mainnet" rel="0x3f;0xbf;0x7d;0xee80286a;0xee8031e8;false;false">ShadowCash (mainnet)</option>
 									<option value="bitcoin_testnet" rel="0x6f;0xef;0xc4;0x043587cf;0x04358394;false;false">Bitcoin (testnet)</option>
 
@@ -1029,6 +1030,7 @@
 									<option value="chain.so_bitcoinmainnet"> Chain.so (Bitcoin mainnet)</option>
 									<option value="blockcypher_bitcoinmainnet"> Blockcypher.com (Bitcoin mainnet)</option>
 									<option value="blockr.io_litecoin"> Blockr.io (Litecoin)</option>
+									<option value="chain.so_dogecoin"> Chain.so (Dogecoin)</option>
 								<!--	<option value="blockr.io_bitcointestnet"> Blockr.io (Bitcoin testnet)</option> -->
 								</select>
 							</div>
@@ -1044,6 +1046,7 @@
 									<option value="coinb.in">coinb.in (Bitcoin mainnet)</option>
 									<option value="blockr.io_bitcoinmainnet"> Blockr.io (Bitcoin mainnet)</option>
 									<option value="chain.so_litecoin"> Chain.so (Litecoin)</option>
+									<option value="chain.so_dogecoin"> Chain.so (Dogecoin)</option>
 								</select>
 							</div>
 						</div>

--- a/js/coin.js
+++ b/js/coin.js
@@ -702,7 +702,7 @@
 		r.spendToScript = function(address){
 			var addr = coinjs.addressDecode(address);
 			var s = coinjs.script();
-			if(addr.version==5){ // multisig address
+			if(addr.version==coinjs.multisig){ // multisig address
 				s.writeOp(169); //OP_HASH160
 				s.writeBytes(addr.bytes);
 				s.writeOp(135); //OP_EQUAL

--- a/js/coinbin.js
+++ b/js/coinbin.js
@@ -683,6 +683,8 @@ $(document).ready(function() {
 			listUnspentBlockrio_BitcoinMainnet(redeem);
 		} else if(host=='chain.so_litecoin'){
 			listUnspentChainso_Litecoin(redeem);
+		}  else if(host=='chain.so_dogecoin'){
+			listUnspentChainso_Dogecoin(redeem);
 		} else {
 			listUnspentDefault(redeem);
 		}
@@ -850,6 +852,40 @@ $(document).ready(function() {
 			success: function(data) {
 				if((data.status && data.data) && data.status=='success'){
 					$("#redeemFromAddress").removeClass('hidden').html('<span class="glyphicon glyphicon-info-sign"></span> Retrieved unspent inputs from address <a href="https://btc.blockr.io/address/info/'+redeem.addr+'" target="_blank">'+redeem.addr+'</a>');
+					for(var i in data.data.txs){
+						var o = data.data.txs[i];
+						var tx = ((o.txid).match(/.{1,2}/g).reverse()).join("")+'';
+						var n = o.output_no;
+						var script = (redeem.isMultisig==true) ? $("#redeemFrom").val() : o.script_hex;
+						var amount = o.value;
+						addOutput(tx, n, script, amount);
+					}
+				} else {
+					$("#redeemFromStatus").removeClass('hidden').html('<span class="glyphicon glyphicon-exclamation-sign"></span> Unexpected error, unable to retrieve unspent outputs.');
+				}
+			},
+			complete: function(data, status) {
+				$("#redeemFromBtn").html("Load").attr('disabled',false);
+				totalInputAmount();
+			}
+		});
+	}
+
+
+	/* retrieve unspent data from chain.so for dogecoin */
+	function listUnspentChainso_Dogecoin(redeem){
+		$.ajax ({
+			type: "GET",
+			url: "https://chain.so/api/v2/get_tx_unspent/doge/"+redeem.addr,
+			dataType: "json",
+			error: function(data) {
+				$("#redeemFromStatus").removeClass('hidden').html('<span class="glyphicon glyphicon-exclamation-sign"></span> Unexpected error, unable to retrieve unspent outputs!');
+			},
+			success: function(data) {
+				if((data.status && data.data) && data.status=='success'){
+					$("#redeemFromAddress").removeClass('hidden').html(
+						'<span class="glyphicon glyphicon-info-sign"></span> Retrieved unspent inputs from address <a href="https://btc.blockr.io/address/info/'+
+						redeem.addr+'" target="_blank">'+redeem.addr+'</a>');
 					for(var i in data.data.txs){
 						var o = data.data.txs[i];
 						var tx = ((o.txid).match(/.{1,2}/g).reverse()).join("")+'';
@@ -1072,6 +1108,43 @@ $(document).ready(function() {
 			}
 		});
 	}
+
+
+	// broadcast transaction via chain.so for dogecoin
+	function rawSubmitchainso_dogecoin(thisbtn){ 
+		$(thisbtn).val('Please wait, loading...').attr('disabled',true);
+                $.ajax ({
+                        type: "POST",
+                        url: "https://chain.so/api/v2/send_tx/DOGE",
+			data: {"tx_hex":$("#rawTransaction").val()},
+                        dataType: "json",
+                        error: function(data) {
+				var obj = $.parseJSON(data.responseText);
+				var r = ' ';
+				r += (obj.data) ? obj.data : '';
+				r += (obj.message) ? ' '+obj.message : '';
+				r = (r!='') ? r : ' Failed to broadcast'; // build response 
+				$("#rawTransactionStatus").addClass('alert-danger').removeClass('alert-success').removeClass("hidden").html(r).prepend('<span class="glyphicon glyphicon-exclamation-sign"></span>');
+				console.error(JSON.stringify(data, null, 4));
+                        },
+                        success: function(data) {
+				console.info(JSON.stringify(data, null, 4));
+				if((data.status && data.data) && data.status=='success'){
+					$("#rawTransactionStatus").addClass('alert-success').removeClass('alert-danger').removeClass("hidden").html(' Txid: ' + data.data.txid);
+				} else {
+					$("#rawTransactionStatus").addClass('alert-danger').removeClass('alert-success').removeClass("hidden").html(
+					' Unexpected error, please try again').prepend('<span class="glyphicon glyphicon-exclamation-sign"></span>');
+				}
+			},
+			complete: function(data, status) {
+				$("#rawTransactionStatus").fadeOut().fadeIn();
+				$(thisbtn).val('Submit').attr('disabled',false);				
+                        }
+                });
+	}
+
+
+
 
 	/* verify script code */
 
@@ -1362,8 +1435,6 @@ $(document).ready(function() {
 		return r;
 	}
 
-	$("#newKeysBtn, #newHDKeysBtn").click();
-
 	var _getBroadcast = _get("broadcast");
 	if(_getBroadcast[0]){
 		$("#rawTransaction").val(_getBroadcast[0]);
@@ -1532,6 +1603,10 @@ $(document).ready(function() {
 		} else if(host=="chain.so_bitcoinmainnet"){
 			$("#rawSubmitBtn").click(function(){
 				rawSubmitChainso_BitcoinMainnet(this);
+			});
+		} else if(host=="chain.so_dogecoin"){
+			$("#rawSubmitBtn").click(function(){
+				rawSubmitchainso_dogecoin(this);
 			});
 		} else if(host=="blockcypher_bitcoinmainnet"){
 			$("#rawSubmitBtn").click(function(){


### PR DESCRIPTION
The modifications required for adding Dogecoin support to coinb.in were minimal. 

Three files were changed. They are:

**index.html:**
Added three lines to the Settings page:
For Settings->Network:
<option value="dogecoin_mainnet" rel="0x1e;0x9e;0x16;0x0827421e;0x089944e4;chain.so_dogecoin;chain.so_dogecoin">Dogecoin (mainnet)</option>
For Settings->Broadcast:
<option value="chain.so_dogecoin"> Chain.so (Dogecoin)</option>
For Settings->Get Unspent TX:
<option value="chain.so_dogecoin"> Chain.so (Dogecoin)</option>

**coinbin.js, 3 items:**
1) New function listUnspentChainso_Dogecoin, used the Litecoin version as a template. 
2) New function rawSubmitchainso_dogecoin, used the Litecoin version as a template.
A couple new 'if else' clauses were added in the code, in support of these two new functions.
3) Deleted the following line previously on line 1365:
$("#newKeysBtn, #newHDKeysBtn").click(); 
This particular function call generates an address based on the default bitcoin parameter settings, even after the user changed the settings to the Litecoin or Dogecoin network (from Broadcast->settings, e.g.). Barring a more substantial change, simply removing this call forces the user to click the generate button, where everything's refreshed and then works fine.


**coin.js:**
One change, line 705, replaced the '5' with 'coinjs.multisig'. This fixes a bug where dogecoin (and other crytpos that don't use 0x05 for multisig) was unable to have an output transaction pay out to a multisig address (a random looking output address would be paid instead).
