### PR TITLE
Fix issue 132 .. UI issue wrt/removing first UTXO

### DIFF
--- a/js/coinbin.js
+++ b/js/coinbin.js
@@ -782,9 +782,25 @@ $(document).ready(function() {
 		window.location = "#fees";
 	});
 
+	// this is when the user clicks on the '-' button on the FIRST row of inputs only
+	// there is a different function for the '-' button on other rows
 	$(".txidClear").click(function(){
-		$("#inputs .row:first input").attr('disabled',false);
-		$("#inputs .row:first input").val("");
+		var numTxIns = $('#inputs div.row').length;
+		if (numTxIns > 1) {
+			// when there are subsequent rows of data we want the
+			// second row data moved into this row, and the second row deleted
+			// github coinbin/issues/132
+			$("#inputs .txId:first").val($("#inputs .txId")[1].value);
+			$("#inputs .txIdN:first").val($("#inputs .txIdN")[1].value);
+			$("#inputs .txIdScript:first").val($("#inputs .txIdScript")[1].value);
+			$("#inputs .txIdAmount:first").val($("#inputs .txIdAmount")[1].value);
+			$(this).parent().parent().next().fadeOut().remove(); // remove the second row
+		}
+		else {
+			$("#inputs .row:first input").val("");
+			// when clearing the first row, enable it so user can enter information manually
+			$("#inputs .row:first input").attr('disabled',false);
+		}
 		totalInputAmount();
 	});
 


### PR DESCRIPTION
This is a UI fix for https://github.com/OutCast3k/coinbin/issues/132 : when user chooses to remove the first row in a list of UTXOs, it will copy the second row data up to the first and remove the second row from the browser.  This is because the first row is perpetual, subsequent rows are transient.  If there is only one row, functionality remains same as before (i.e. it is cleared and enabled for editing manually).