### PR TITLE
Fix issue 195 .. add bitcoin testnet with blockcypher

### DIFF
--- a/index.html
+++ b/index.html
@@ -1357,8 +1357,7 @@
 									<option value="dogecoin_mainnet" rel="0x1e;0x9e;0x16;0x0827421e;0x089944e4;blockcypher_dogecoin;blockcypher_dogecoin">Dogecoin (mainnet)</option>
 									<option value="carboncoin_mainnet" rel="0x2f;0xaf;0x05;0x488b21e;0x488ade4;cryptoid.info_carboncoin;cryptoid.info_carboncoin">Carboncoin (mainnet)</option>
 									<option value="shadowcash_mainnet" rel="0x3f;0xbf;0x7d;0xee80286a;0xee8031e8;false;false">ShadowCash (mainnet)</option>
-									<option value="bitcoin_testnet" rel="0x6f;0xef;0xc4;0x043587cf;0x04358394;false;false">Bitcoin (testnet)</option>
-
+									<option value="bitcoin_testnet" rel="0x6f;0xef;0xc4;0x043587cf;0x04358394;blockcypher_bitcointestnet;blockcypher_bitcointestnet">Bitcoin (testnet)</option>
 									<option value="custom" rel="0x00;0x80;0x05;0x488b21e;0x488ade4;false;false">Custom</option>
 								</select>
 							</div>
@@ -1421,6 +1420,7 @@
 									<option value="chain.so_litecoin"> Chain.so (Litecoin)</option>
 									<option value="chain.so_dogecoin"> Chain.so (Dogecoin)</option>
 									<option value="cryptoid.info_carboncoin"> Cryptoid.info (Carboncoin)</option>
+									<option value="blockcypher_bitcointestnet"> Blockcypher.com (Bitcoin testnet)</option>
 								</select>
 							</div>
 						</div>
@@ -1443,6 +1443,7 @@
 									<option value="chain.so_litecoin"> Chain.so (Litecoin)</option>
 									<option value="chain.so_dogecoin"> Chain.so (Dogecoin)</option>
 									<option value="cryptoid.info_carboncoin"> Cryptoid.info (Carboncoin)</option>
+									<option value="blockcypher_bitcointestnet"> Blockcypher.com (Bitcoin testnet)</option>
 								</select>
 							</div>
 						</div>

--- a/js/coinbin.js
+++ b/js/coinbin.js
@@ -911,7 +911,7 @@ $(document).ready(function() {
         // network name     "btc"           "bitcoin"       "BTC"
         // network name     "ltc"           "litecoin"      "LTC"
         // network name     "doge"          "dogecoin"      "DOGE"
-        debugger;
+
 		if(host=='chain.so_bitcoinmainnet'){
 			listUnspentChainso(redeem, "BTC");
         } else if(host=='chain.so_litecoin'){
@@ -933,6 +933,8 @@ $(document).ready(function() {
 		} else if(host=='blockchair_dogecoin'){
 			listUnspentBlockchair(redeem, "dogecoin");
 
+		} else if(host=='blockcypher_bitcointestnet'){
+			listUnspentBlockcypherTest(redeem, "btc");
 		} else if(host=='cryptoid.info_carboncoin'){
 			listUnspentCryptoidinfo_Carboncoin(redeem);
 		} else {
@@ -1081,6 +1083,41 @@ $(document).ready(function() {
 		$.ajax ({
 			type: "GET",
 			url: "https://api.blockcypher.com/v1/"+network+"/main/addrs/"+redeem.addr+"?includeScript=true&unspentOnly=true",
+			dataType: "json",
+			error: function(data) {
+				$("#redeemFromStatus").removeClass('hidden').html('<span class="glyphicon glyphicon-exclamation-sign"></span> Unexpected error, unable to retrieve unspent outputs!');
+			},
+			success: function(data) {
+				if (data.address) { // address field will always be present, txrefs is only present if there are UTXOs
+					$("#redeemFromAddress").removeClass('hidden').html(
+						'<span class="glyphicon glyphicon-info-sign"></span> Retrieved unspent inputs from address <a href="'+explorer_addr+redeem.addr+'" target="_blank">'+redeem.addr+'</a>');
+					for(var i in data.txrefs){
+                        var o = data.txrefs[i]
+						var tx = ((""+o.tx_hash).match(/.{1,2}/g).reverse()).join("")+'';
+						if(tx.match(/^[a-f0-9]+$/)){
+							var n = o.tx_output_n;
+							var script = (redeem.redeemscript==true) ? redeem.decodedRs : o.script;
+							var amount = ((o.value.toString()*1)/100000000).toFixed(8);
+							addOutput(tx, n, script, amount);
+						}
+					}
+				} else {
+					$("#redeemFromStatus").removeClass('hidden').html('<span class="glyphicon glyphicon-exclamation-sign"></span> Unexpected error, unable to retrieve unspent outputs.');
+				}
+			},
+			complete: function(data, status) {
+				$("#redeemFromBtn").html("Load").attr('disabled',false);
+				totalInputAmount();
+			}
+		});
+	}
+
+
+	/* retrieve unspent data from blockcypher TESTNET */
+	function listUnspentBlockcypherTest(redeem,network){
+		$.ajax ({
+			type: "GET",
+			url: "https://api.blockcypher.com/v1/"+network+"/test3/addrs/"+redeem.addr+"?includeScript=true&unspentOnly=true",
 			dataType: "json",
 			error: function(data) {
 				$("#redeemFromStatus").removeClass('hidden').html('<span class="glyphicon glyphicon-exclamation-sign"></span> Unexpected error, unable to retrieve unspent outputs!');
@@ -1377,6 +1414,32 @@ $(document).ready(function() {
 			complete: function(data, status) {
 				$("#rawTransactionStatus").fadeOut().fadeIn();
 				$(thisbtn).val('Submit').attr('disabled',false);				
+			}
+		});
+	}
+
+	// broadcast transaction via blockcypher.com (testnet)
+	function rawSubmitblockcypherTest(thisbtn, network){
+		$(thisbtn).val('Please wait, loading...').attr('disabled',true);
+		$.ajax ({
+			type: "POST",
+			url: "https://api.blockcypher.com/v1/"+network+"/test3/txs/push",
+			data: JSON.stringify({"tx":$("#rawTransaction").val()}),
+			error: function(data) {
+				var r = 'Failed to broadcast: error code=' + data.status.toString() + ' ' + data.statusText;
+				$("#rawTransactionStatus").addClass('alert-danger').removeClass('alert-success').removeClass("hidden").html(r).prepend('<span class="glyphicon glyphicon-exclamation-sign"></span>');
+			},
+                        success: function(data) {
+				if((data.tx) && data.tx.hash){
+					$("#rawTransactionStatus").addClass('alert-success').removeClass('alert-danger').removeClass("hidden")
+                    .html(' TXID: ' + data.tx.hash + '<br> <a href="https://live.blockcypher.com/'+network+'-testnet/tx/' + data.tx.hash + '" target="_blank">View on Blockchain Explorer</a>');
+				} else {
+					$("#rawTransactionStatus").addClass('alert-danger').removeClass('alert-success').removeClass("hidden").html(' Unexpected error, please try again').prepend('<span class="glyphicon glyphicon-exclamation-sign"></span>');
+				}
+			},
+			complete: function(data, status) {
+				$("#rawTransactionStatus").fadeOut().fadeIn();
+				$(thisbtn).val('Submit').attr('disabled',false);
 			}
 		});
 	}
@@ -1957,6 +2020,10 @@ $(document).ready(function() {
 		} else if(host=="cryptoid.info_carboncoin"){
 			$("#rawSubmitBtn").click(function(){
 				rawSubmitcryptoid_Carboncoin(this);
+			});
+		} else if(host=="blockcypher_bitcointestnet"){
+			$("#rawSubmitBtn").click(function(){
+				rawSubmitblockcypherTest(this, "btc");
 			});
 		} else {
 			$("#rawSubmitBtn").click(function(){


### PR DESCRIPTION
This is a small change to address https://github.com/OutCast3k/coinbin/issues/195.
Bitcoin testnet support added with unspent outputs and broadcast routines via blockcypher.
Has no impact on the other coins or backend configs.