### PR TITLE
warn if script could not be signed

### DIFF
--- a/js/coin.js
+++ b/js/coin.js
@@ -1584,7 +1584,7 @@
 		}
 
 		/* sign inputs */
-		r.sign = function(wif, sigHashType){
+		r.sign = function(wif, sigHashType, warnings){
 			var shType = sigHashType || 1;
 			for (var i = 0; i < this.ins.length; i++) {
 				var d = this.extractScriptKey(i);
@@ -1607,6 +1607,7 @@
 
 				} else {
 					// could not sign
+					warnings.push("could not sign input "+(i+1)+" using the supplied private key");
 				}
 			}
 			return this.serialize();

--- a/js/coinbin.js
+++ b/js/coinbin.js
@@ -1678,6 +1678,8 @@ $(document).ready(function() {
 	$("#signBtn").click(function(){
 		var wifkey = $("#signPrivateKey");
 		var script = $("#signTransaction");
+		wifkey.val(wifkey.val().trimLeft().trimRight()); // sanitize
+		script.val(script.val().trimLeft().trimRight()); // sanitize
 
 		if(coinjs.addressDecode(wifkey.val())){
 			$(wifkey).parent().removeClass('has-error');
@@ -1696,8 +1698,17 @@ $(document).ready(function() {
 			try {
 				var tx = coinjs.transaction();
 				var t = tx.deserialize(script.val());
-
-				var signed = t.sign(wifkey.val(), $("#sighashType option:selected").val());
+				var warnings = new Array();
+				var signed = t.sign(wifkey.val(), $("#sighashType option:selected").val(), warnings);
+				if (signed == script.val()) {
+					// if signed script is identical to the input,
+					// output a warning telling user to check inputs.
+					// most likely they chose the wrong WIF key for signing
+					$("#signedDataError").removeClass('hidden');
+					if (warnings.length > 0) {
+						$("#signedDataError").html("Warning: " + warnings.toString());
+					}
+				}
 				$("#signedData textarea").val(signed);
 				$("#signedData .txSize").html(t.size());
 				$("#signedData").removeClass('hidden').fadeIn();
@@ -1705,6 +1716,7 @@ $(document).ready(function() {
 				// console.log(e);
 			}
 		} else {
+			$("#signedDataError").html("There is a problem with one or more of your inputs, please check and try again");
 			$("#signedDataError").removeClass('hidden');
 			$("#signedData").addClass('hidden');
 		}


### PR DESCRIPTION
If you use the wrong key when signing it doesn't error out, it just returns the same unsigned raw transaction back to you saying the transaction has been signed (https://github.com/OutCast3k/coinbin/issues/76#issuecomment-309980912) (https://github.com/OutCast3k/coinbin/issues/165) (https://github.com/OutCast3k/coinbin/issues/64).  This change reports the error to the user when signing fails.  Also, the user inputs are sanitized by removing spurious whitespace. (https://github.com/OutCast3k/coinbin/issues/120)