### PR TITLE
fix: RBF always set when redeeming OP_CHECKLOCKTIMEVERIFY

### DIFF
--- a/js/coinbin.js
+++ b/js/coinbin.js
@@ -171,7 +171,7 @@ $(document).ready(function() {
 			script = sw.redeemscript;
 		}
 
-		var sequence = false;
+		var sequence = 0xffffffff-1;
 		if($("#walletRBF").is(":checked")){
 			sequence = 0xffffffff-2;
 		}
@@ -656,7 +656,7 @@ $(document).ready(function() {
 			}
 
 			if(!$(o).hasClass("has-error")){
-				var seq = null;
+				var seq = 0xffffffff-1;
 				if($("#txRBF").is(":checked")){
 					seq = 0xffffffff-2;
 				}


### PR DESCRIPTION
Replace by Fee was always "on" for time lock redemptions.  Please see https://github.com/OutCast3k/coinbin/issues/193 for exhaustive information on this.

(Testing is vastly easier if you also use PR https://github.com/OutCast3k/coinbin/pull/196 - enable testnet interoperability with Blockcypher).