### PR TITLE
Make HD wallet compatible with wallets generated on https://bip32.org and `bitcoin-cli`

### DIFF
--- a/index.html
+++ b/index.html
@@ -1193,14 +1193,14 @@
 							<div class="row">
 								<div class="col-md-8">
 									<b>Path</b><br>
-									<select class="form-control" id="hdpathtype"">
+									<select class="form-control" id="hdpathtype">
 										<option value="simple">Simple: m/i</option>
 										<option value="custom">Custom</option>
 									</select>
 
 									<div id="hdpath" class="hidden" style="margin-top:4px">
 										<span class="input-group">
-											<input type="text" class="form-control" value="m/0/1">  <br>
+											<input type="text" class="form-control" value="m/0/1" title="WARNING: see #settings page when using hardened paths!">  <br>
 											<span class="input-group-addon"> / </span>
 										</span>
 									</div>
@@ -1452,6 +1452,19 @@
 									<option value="chain.so_litecoin"> Chain.so (Litecoin)</option>
 									<option value="chain.so_dogecoin"> Chain.so (Dogecoin)</option>
 									<option value="cryptoid.info_carboncoin"> Cryptoid.info (Carboncoin)</option>
+								</select>
+							</div>
+						</div>
+
+						<hr>
+
+						<div class="row">
+							<div class="col-md-12">
+								<b>HD wallet hardened path derivation</b>: <br>
+								<p class="text-muted">The path derivation for hardened paths was calculated wrong in earlier versions of coinb.in. Please select the old path derivation to recover HD wallet keys generated with older version of coinb.in.</p>
+								<select class="form-control" id="coinjs_derivation">
+									<option value="bip32_derivation">BIP32 compliant derivation</option>
+									<option value="coinbin_broken">Old (broken) coinb.in path derivation</option>
 								</select>
 							</div>
 						</div>

--- a/js/coin.js
+++ b/js/coin.js
@@ -18,6 +18,8 @@
 
 	coinjs.compressed = false;
 
+	coinjs.hd_derivation = "bip32_derivation";
+
 	/* other vars */
 	coinjs.developer = '33tht1bKDgZVxb39MnZsWa8oxHXHvUYE4G'; //bitcoin
 
@@ -685,7 +687,11 @@
 		r.derive = function(i){
 
 			i = (i)?i:0;
-			var blob = (Crypto.util.hexToBytes(this.keys.pubkey)).concat(coinjs.numToBytes(i,4).reverse());
+			if ((i >= 0x80000000) && (coinjs.hd_derivation == "bip32_derivation")) {
+				var blob = (Crypto.util.hexToBytes("00").concat(Crypto.util.hexToBytes(this.keys.privkey)).concat(coinjs.numToBytes(i,4).reverse()));
+			} else {
+				var blob = (Crypto.util.hexToBytes(this.keys.pubkey)).concat(coinjs.numToBytes(i,4).reverse());
+			}
 
 			var j = new jsSHA(Crypto.util.bytesToHex(blob), 'HEX');
  			var hash = j.getHMAC(Crypto.util.bytesToHex(r.chain_code), "HEX", "SHA-512", "HEX");

--- a/js/coinbin.js
+++ b/js/coinbin.js
@@ -1701,15 +1701,23 @@ $(document).ready(function() {
 
 	function deriveHDaddress() {
 		var hd = coinjs.hd($("#verifyHDaddress .hdKey").html());
-		var index_start = $("#verifyHDaddress .derivation_index_start").val()*1;
-		var index_end = $("#verifyHDaddress .derivation_index_end").val()*1;
+		var index_start = $("#verifyHDaddress .derivation_index_start").val();
+		if ((index_start.length > 1) && (index_start[index_start.length - 1] == '\'')) {
+			var use_private_index = '\'';
+			index_start = index_start.replace(/[']/, "") * 1;
+		} else {
+			var use_private_index = '';
+			index_start = index_start.replace(/[']/, "") * 1;
+		}
+		var index_end = $("#verifyHDaddress .derivation_index_end").val().replace(/[']/, "") * 1;
+		$("#verifyHDaddress .derivation_index_end").val(index_end + use_private_index);
 		var html = '';
 		$("#verifyHDaddress .derived_data table tbody").html("");
 		for(var i=index_start;i<=index_end;i++){
 			if($("#hdpathtype option:selected").val()=='simple'){
 				var derived = hd.derive(i);
 			} else {
-				var derived = hd.derive_path(($("#hdpath input").val().replace(/\/+$/, ""))+'/'+i);
+				var derived = hd.derive_path(($("#hdpath input").val().replace(/\/+$/, ""))+'/'+i+use_private_index);
 			}
 			html += '<tr>';
 			html += '<td>'+i+'</td>';
@@ -1914,6 +1922,8 @@ $(document).ready(function() {
 			coinjs.hdkey.pub =  $("#coinjs_hdpub").val()*1;
 			coinjs.hdkey.prv =  $("#coinjs_hdprv").val()*1;
 
+			coinjs.hd_derivation =  $("#coinjs_derivation").val();
+
 			configureBroadcast();
 			configureGetUnspentTx();
 
@@ -1959,6 +1969,7 @@ $(document).ready(function() {
 		$("#coinjs_multisig").val(o[2]);
 		$("#coinjs_hdpub").val(o[3]);
 		$("#coinjs_hdprv").val(o[4]);
+		$("#coinjs_derivation").val(o[7]);
 
 		// hide/show custom screen
 		if($("option:selected",this).val()=="custom"){


### PR DESCRIPTION
This pull request fixes issue #227 and makes the generation of private (in current BIP32 document named as "hardened") path components handling conform to BIP32. It allows also specifying start/end index with a `'` at the end to mark, that the index should be also private. Now it is possible to generate such paths:
- `m/k'/0/i` - like default pah on BIP32
- `m/0'/0'/i'` - these paths are usually generated in bitcoin core (visible when you do `bitcoin-cli dumpwallet`)