### PR TITLE
Use HMAC SHA-256 with configurable amount of rounds to generate seed

### DIFF
--- a/index.html
+++ b/index.html
@@ -582,12 +582,27 @@
 							</span>
 						</div>
 
+						<label>Seed (WIF)</label>
+						<div class="input-group">
+							<input id="newHDseed" type="text" class="form-control" value="" readonly>
+							<span class="input-group-btn">
+								<button class="deriveHDbtn btn btn-default" type="button"><span title="Derive from key" class="glyphicon glyphicon-chevron-right"></span></button>
+							</span>
+						</div>
+
 						<h3>Address Options</h3>
 						<p>You can use the advanced options below to generate different kinds of master addresses.</p>
 						
 						<div class="checkbox">
 							<label><input type="checkbox" id="newHDBrainwallet" class="checkbox-inline"> Custom Seed or Brain Wallet</label>
-							<input type="text" class="form-control hidden" id="HDBrainwallet">
+							<div class="hidden" id="HDBrainwalletInput">
+								<input type="text" class="form-control" id="HDBrainwallet">
+								<span class="text-muted">
+									Number of HMAC SHA-256 iterations for seed generation, higher value mean's also longer calculation
+									(use value 0 to calculate just SHA-256, like in previous coinb.in versions):
+									<input type="text" class="form-control" id="HDBrainwalletIters" value="50000" size="10">
+								</span>
+							</div>
 						</div>
 
 						<input type="button" class="btn btn-primary" value="Generate" id="newHDKeysBtn">

--- a/js/coinbin.js
+++ b/js/coinbin.js
@@ -570,18 +570,20 @@ $(document).ready(function() {
 	$("#newHDKeysBtn").click(function(){
 		coinjs.compressed = true;
 		var s = ($("#newHDBrainwallet").is(":checked")) ? $("#HDBrainwallet").val() : null;
+		var siters = ($("#newHDBrainwallet").is(":checked")) ? $("#HDBrainwalletIters").val()*1 : null;
 		var hd = coinjs.hd();
-		var pair = hd.master(s);
+		var pair = hd.master(s, siters);
 		$("#newHDxpub").val(pair.pubkey);
 		$("#newHDxprv").val(pair.privkey);
+		$("#newHDseed").val(pair.seed_wif);
 
 	});
 
 	$("#newHDBrainwallet").click(function(){
 		if($(this).is(":checked")){
-			$("#HDBrainwallet").removeClass("hidden");
+			$("#HDBrainwalletInput").removeClass("hidden");
 		} else {
-			$("#HDBrainwallet").addClass("hidden");
+			$("#HDBrainwalletInput").addClass("hidden");
 		}
 	});
 
@@ -1681,6 +1683,7 @@ $(document).ready(function() {
 			if(hex == hex_cmp_prv || hex == hex_cmp_pub){
 				var hd = coinjs.hd(s);
 				$("#verifyHDaddress .hdKey").html(s);
+				$("#verifyHDaddress .seed_wif").val(hd.seed_wif);
 				$("#verifyHDaddress .chain_code").val(Crypto.util.bytesToHex(hd.chain_code));
 				$("#verifyHDaddress .depth").val(hd.depth);
 				$("#verifyHDaddress .version").val('0x'+(hd.version).toString(16));


### PR DESCRIPTION
With this change coinb.in uses the same mechanism to generate seed from a passphrase like https://bip32.org: 50000 rounds of HMAC SHA-256 encryption.

The amount of rounds is configurable and the value `0` results in the same mechanism as before for compatibility. The generated seed is also shown in WIF format, which is also with `bitcoin-cli` compatible. It is possible now to generate the same wallet using `bitcoin-cli sethdseed true <seed_wif>` command in bitcoin core.

To be really fully compatible with `bitcoin-cli`, the fix in #228 pull request is also required.